### PR TITLE
Fixing checkboxes after High Isles Patch 

### DIFF
--- a/Controls.lua
+++ b/Controls.lua
@@ -33,26 +33,24 @@ function createCheckbox(parent, name, sizeX, sizeY, xOffset, yOffset, fromAnchor
 		PlaySound(SOUNDS.DEFAULT_CLICK)
         checkbox.data = not checkbox.data
         if checkbox.data then
-            checkbox:SetTexture("/esoui/art/buttons/checkbox_checked.dds")
+            checkbox:SetNormalTexture("/esoui/art/buttons/checkbox_checked.dds")
         else
-            checkbox:SetTexture("/esoui/art/buttons/checkbox_unchecked.dds")
+            checkbox:SetNormalTexture("/esoui/art/buttons/checkbox_unchecked.dds")
         end
         checkboxFunction(checkbox.data)
     end)
-    checkbox:SetAnchor(fromAnchor, parent, toAnchor, xOffset, yOffset)
-    checkbox:SetDimensions(sizeX, sizeY)
     if checkbox.data then
-        checkbox:SetTexture("/esoui/art/buttons/checkbox_checked.dds")
+        checkbox:SetNormalTexture("/esoui/art/buttons/checkbox_checked.dds")
     else
-        checkbox:SetTexture("/esoui/art/buttons/checkbox_unchecked.dds")
+        checkbox:SetNormalTexture("/esoui/art/buttons/checkbox_unchecked.dds")
     end
 
     local function Update(self, newValue)
         self.data = newValue
         if self.data then
-            self:SetTexture("/esoui/art/buttons/checkbox_checked.dds")
+            self:SetNormalTexture("/esoui/art/buttons/checkbox_checked.dds")
         else
-            self:SetTexture("/esoui/art/buttons/checkbox_unchecked.dds")
+            self:SetNormalTexture("/esoui/art/buttons/checkbox_unchecked.dds")
         end
     end
 

--- a/Controls.lua
+++ b/Controls.lua
@@ -26,7 +26,7 @@ function createButton(parent, name, sizeX, sizeY, xOffset, yOffset, fromAnchor, 
 end
 
 function createCheckbox(parent, name, sizeX, sizeY, xOffset, yOffset, fromAnchor, toAnchor, defaultValue, checkboxFunction,labelText,labelLength)
-    local checkbox = WM:CreateControl("$(parent)" .. name, parent, CT_TEXTURE)
+    local checkbox = WM:CreateControl("$(parent)" .. name, parent, CT_BUTTON)
     checkbox.data = defaultValue
     checkbox:SetMouseEnabled(true)
     checkbox:SetHandler("OnMouseUp", function(_, _, _)


### PR DESCRIPTION
Since High Isles checkboxes have been unusable.
Even disabling all other addons didnt help so it might not be a conflict between libraries.

I changed the control type to CT_BUTTON ( which seems more fitting for checkboxes) and kept the initial "setTexture" thingy.

