### PR TITLE
Global class filter

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -13,6 +13,15 @@ HT_targets = {
     end,
 }
 
+HT_classNames = {
+	[1] = "Dragonknight",
+	[2] = "Sorcerer",
+	[3] = "Nightblade",
+	[4] = "Warden",
+	[5] = "Necromancer",
+	[6] = "Templar"
+}
+
 operators = {
     ["<="] = function(arg1, arg2)
         if arg1 <= arg2 then

--- a/GlobalControl.lua
+++ b/GlobalControl.lua
@@ -11,7 +11,7 @@ function HT_processLoad(trackerLoad)
     if trackerLoad.role ~= GetGroupMemberSelectedRole("player") and trackerLoad.role ~= 0 and GetGroupMemberSelectedRole("player") ~= 0 then
         return false
     end
-    if trackerLoad.class ~= GetUnitClass("player") and trackerLoad.class ~= "Any" then
+    if trackerLoad.class ~= HT_classNames[GetUnitClassId("player")] and trackerLoad.class ~= "Any" then
         return false
     end
     if not HT_checkIfSkillSlotted(trackerLoad.skills) then


### PR DESCRIPTION
The class filter is currently broken on any non-English client.
This fix identifies the classes by their ids rather than by their names.