### PR TITLE
:globe_with_meridians: Global target detection

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -1,6 +1,6 @@
 HT_targets = {
     ["Yourself"] = function()
-        return GetUnitName("player")
+        return zo_strformat("<<C:1>>", GetUnitName("player"))
     end,
     ["Boss"] = function(i)
         return GetUnitName("boss" .. i)
@@ -9,7 +9,7 @@ HT_targets = {
         return GetUnitName("reticleover")
     end,
     ["Group"] = function(i)
-        return GetUnitName("group" .. i)
+        return zo_strformat("<<C:1>>", GetUnitName("group" .. i))
     end,
 }
 

--- a/Events.lua
+++ b/Events.lua
@@ -13,7 +13,7 @@ end
 local eventFunctions = {
     ["Get Effect Duration"] = function(name, ID, tracker, arguments)
         EVENT_MANAGER:RegisterForEvent(name, EVENT_EFFECT_CHANGED, function(_, result, _, _, _, _, expireTime, stackCount, _, _, _, _, _, targetName,targetId)
-            targetName = zo_strformat("<<1>>", targetName)
+            targetName = zo_strformat("<<C:1>>", targetName)
             if not arguments.dontUpdateFromThisEvent then
                 if expireTime > (tracker.expiresAt[targetName] or 0) or (not arguments.overwriteShorterDuration) then
                     tracker.expiresAt[targetName] = expireTime
@@ -54,7 +54,7 @@ local eventFunctions = {
                 hyperToolsTracker = tracker
                 hyperToolsGlobal.result = result
                 hyperToolsGlobal.hitValue = hitValue
-                hyperToolsGlobal.targetName = zo_strformat("<<1>>", sourceName)
+                hyperToolsGlobal.targetName = zo_strformat("<<C:1>>", sourceName)
                 zo_loadstring(arguments.luaCodeToExecute)()
                 hyperToolsGlobal = {}
                 tracker = hyperToolsTracker

--- a/UtilityFunctions.lua
+++ b/UtilityFunctions.lua
@@ -75,7 +75,13 @@ function HT_checkIfSkillSlotted(skillIDTable)
     for _, skillID in pairs(skillIDTable) do
         for i = 3, 8 do
             local slot1 = GetSlotBoundId(i, HOTBAR_CATEGORY_PRIMARY)
+            if GetSlotType(i, HOTBAR_CATEGORY_PRIMARY) == ACTION_TYPE_CRAFTED_ABILITY then
+                slot1 = GetAbilityIdForCraftedAbilityId(slot1)
+            end
             local slot2 = GetSlotBoundId(i, HOTBAR_CATEGORY_BACKUP)
+            if GetSlotType(i, HOTBAR_CATEGORY_BACKUP) == ACTION_TYPE_CRAFTED_ABILITY then
+                slot2 = GetAbilityIdForCraftedAbilityId(slot2)
+            end
             if skillID == slot1 or skillID == slot2 then
                 return true, skillID
             end


### PR DESCRIPTION
Depending on the language the target name is sometimes different than the one returned by the reticle.
Setting the first letter of the target to uppercase fixes the issue.
